### PR TITLE
Throw on invalid input

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
 'use strict';
 const pReduce = require('p-reduce');
+const is = require('@sindresorhus/is');
 
 module.exports = iterable => {
 	const ret = [];
+
+	for (const task of iterable) {
+		const type = is(task);
+
+		if (type !== 'Function') {
+			return Promise.reject(new TypeError(`Expected task to be a \`Function\`, received \`${type}\``));
+		}
+	}
+
 	return pReduce(iterable, (_, fn) => {
 		return Promise.resolve().then(fn).then(val => {
 			ret.push(val);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bluebird"
   ],
   "dependencies": {
+    "@sindresorhus/is": "^0.7.0",
     "p-reduce": "^1.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test(async t => {
 	const input = [
@@ -12,4 +12,10 @@ test(async t => {
 
 	const fixtureErr = new Error('fixture');
 	await t.throws(m([async () => Promise.reject(fixtureErr)]), fixtureErr.message);
+});
+
+test('throw if input is not a function', async t => {
+	const input = [Promise.resolve(1 + 1)];
+	const type = /^v4\./.test(process.version) ? 'Object' : 'Promise';
+	await t.throws(m(input), `Expected task to be a \`Function\`, received \`${type}\``);
 });


### PR DESCRIPTION
Had to iterate through the input before the call to `pReduce` since it returns the resolved values and not the inputted ones.

Also used `is` here so we get a better error message if the task is a `Promise` for instance.

Fixes #1.